### PR TITLE
Prevents an Undefined constant error under PHP 8.1

### DIFF
--- a/src/Resources/contao/templates/mod_om_search_keywords.html5
+++ b/src/Resources/contao/templates/mod_om_search_keywords.html5
@@ -16,7 +16,7 @@
             </div>
             <?php endif; ?>
             <input type="submit" name="exportData" class="tl_submit" value="<?= $this->lang['export']; ?>"<?php if (!$this->lastKeywords): ?> disabled<?php endif; ?>>
-            <input type="submit" name="truncateTable" class="tl_submit" value="<?= $this->lang['truncate']; ?>" onclick="if (!confirm('<?= $this->lang[truncateConfirm]; ?>')) return false;" <?php if (!$this->lastKeywords): ?> disabled<?php endif; ?>>
+            <input type="submit" name="truncateTable" class="tl_submit" value="<?= $this->lang['truncate']; ?>" onclick="if (!confirm('<?= $this->lang['truncateConfirm']; ?>')) return false;" <?php if (!$this->lastKeywords): ?> disabled<?php endif; ?>>
         </form>
         <div class="clear"></div>
     </div>


### PR DESCRIPTION
This commit fixes a bug in PHP8.1
Error constant truncate not defined. 
In PHP 8.1 the inverted commas are required for the array key 